### PR TITLE
Adds missing Exit()

### DIFF
--- a/main.go
+++ b/main.go
@@ -128,6 +128,7 @@ func main() {
 	go func() {
 		for range signals {
 			cancel()
+			os.Exit(0)
 		}
 	}()
 


### PR DESCRIPTION
Adds missing `os.Exit(0)` to return 0 when killed using `SIGINT` or `SIGTERM`.